### PR TITLE
Fix sub-sankey links

### DIFF
--- a/index.html
+++ b/index.html
@@ -398,7 +398,7 @@
             display: flex;
             flex-direction: column;
             position: relative;
-            height: 70vh; /* Altura fija para el contenedor */
+            height: 90vh; /* Altura fija para el contenedor */
         }
 
         footer {
@@ -946,7 +946,7 @@
 
             <div id="sub-sankey-container" class="card-inset" style="display: none; margin-top: 2rem;">
                 <h4>Vista Detallada del Flujo (Nodos Arrastrables)</h4>
-                <div id="sub-sankey-chart" style="height: 400px; width: 100%;"></div>
+                <div id="sub-sankey-chart" style="height: 600px; width: 100%;"></div>
                 <button id="export-sub-sankey" class="btn" style="margin-top: 1rem;">Descargar Vista Detallada</button>
             </div>
         </div>
@@ -1109,6 +1109,8 @@
                     },
                     series: [{
                         type: 'sankey',
+                        top: 20,
+                        bottom: 20,
                         roam: true, // Habilitar zoom y arrastre
                         data: nodes,
                         links: currentLinks,
@@ -1603,79 +1605,49 @@
                 }
                 subSankeyChart = echarts.init(subChartDom);
 
-                const nodes = [];
                 const links = [];
                 const nodeMap = new Map();
                 const totalFlow = centerNodeInfo.inflow > 0 ? centerNodeInfo.inflow : centerNodeInfo.outflow;
 
-                // Función para escalar el tamaño de los nodos (alto del rectángulo)
-                const scaleNodeSize = (value) => {
-                    if (totalFlow === 0) return [30, 30]; // Tamaño base
-                    const height = Math.max(20, (value / totalFlow) * 200 + 15); // Mínimo 20px de alto
-                    return [30, height]; // Ancho fijo, alto proporcional
-                };
-
-                // Función para escalar el grosor de los enlaces
-                const scaleLinkWidth = (value) => {
-                    if (totalFlow === 0) return 1;
-                    return Math.max(1, (value / totalFlow) * 25);
-                };
-
-                // Añadir el nodo central
+                // Registrar nodo central
                 nodeMap.set(centerNodeName, {
-                    name: `${centerNodeName}\n(${formatNumber(totalFlow)})`,
+                    name: centerNodeName,
                     value: totalFlow,
-                    symbol: 'rect',
-                    symbolSize: scaleNodeSize(totalFlow),
-                    fixed: true, // El nodo central no se mueve
-                    x: subChartDom.clientWidth / 2,
-                    y: subChartDom.clientHeight / 2,
-                    itemStyle: { color: centerNodeInfo.itemStyle.color },
-                    label: { fontSize: 12, fontWeight: 'bold' }
+                    itemStyle: { color: centerNodeInfo.itemStyle.color }
                 });
 
-                // Añadir nodos de entrada
-                inflows.forEach((link, i) => {
+                // Registrar nodos de entrada y enlaces
+                inflows.forEach(link => {
                     const sourceNode = allNodes.get(link.source);
                     nodeMap.set(link.source, {
-                        name: `${link.source}\n(${formatNumber(link.value)})`,
+                        name: link.source,
                         value: link.value,
-                        symbol: 'rect',
-                        symbolSize: scaleNodeSize(link.value),
-                        itemStyle: { color: sourceNode.itemStyle.color },
-                        x: subChartDom.clientWidth * 0.1,
-                        y: (subChartDom.clientHeight / (inflows.length + 1)) * (i + 1)
+                        itemStyle: { color: sourceNode.itemStyle.color }
                     });
                     links.push({
                         source: link.source,
                         target: centerNodeName,
                         value: link.value,
                         lineStyle: {
-                            width: scaleLinkWidth(link.value),
                             color: sourceNode.itemStyle.color || '#888',
                             opacity: 0.7
                         }
                     });
                 });
 
-                // Añadir nodos de salida
-                outflows.forEach((link, i) => {
+                // Registrar nodos de salida y enlaces
+                outflows.forEach(link => {
                     const targetNode = allNodes.get(link.target);
                     nodeMap.set(link.target, {
-                        name: `${link.target}\n(${formatNumber(link.value)})`,
+                        name: link.target,
                         value: link.value,
-                        symbol: 'rect',
-                        symbolSize: scaleNodeSize(link.value),
-                        itemStyle: { color: targetNode.itemStyle.color },
-                        x: subChartDom.clientWidth * 0.9,
-                        y: (subChartDom.clientHeight / (outflows.length + 1)) * (i + 1)
+                        itemStyle: { color: targetNode.itemStyle.color }
                     });
                     links.push({
                         source: centerNodeName,
                         target: link.target,
                         value: link.value,
                         lineStyle: {
-                            width: scaleLinkWidth(link.value),
                             color: centerNodeInfo.itemStyle.color || '#888',
                             opacity: 0.7
                         }
@@ -1685,21 +1657,45 @@
                 const option = {
                     tooltip: {},
                     series: [{
-                        type: 'graph',
-                        layout: 'none',
-                        roam: false,
-                        draggable: true,
+                        type: 'sankey',
+                        top: 20,
+                        bottom: 20,
                         data: Array.from(nodeMap.values()),
                         links: links,
-                        edgeSymbol: ['none', 'arrow'],
-                        edgeSymbolSize: 10,
-                        label: { show: true, position: 'inside', formatter: '{b}', color: '#fff', textBorderColor: '#000', textBorderWidth: 2 },
+                        nodeWidth: 30,
+                        nodeGap: 30,
+                        label: {
+                            formatter: function(params) {
+                                return params.data.name;
+                            },
+                            color: '#000',
+                            fontSize: 12,
+                            fontWeight: 'bold'
+                        },
+                        edgeLabel: {
+                            show: true,
+                            color: '#000',
+                            fontSize: 11,
+                            formatter: function(params) {
+                                return formatNumber(params.data.value);
+                            }
+                        },
+                        labelLayout: function(params) {
+                            if (params.dataType === 'edge') {
+                                const link = links[params.dataIndex];
+                                const isInflow = link.target === centerNodeName;
+                                return {
+                                    x: params.labelRect.x + (isInflow ? -8 : 8),
+                                    align: isInflow ? 'right' : 'left',
+                                    verticalAlign: 'middle'
+                                };
+                            }
+                        },
                         lineStyle: {
-                            curveness: 0.3,
+                            curveness: 0.5
                         },
                         emphasis: {
-                            focus: 'adjacency',
-                            lineStyle: { width: 10 }
+                            focus: 'adjacency'
                         }
                     }]
                 };
@@ -1708,7 +1704,12 @@
 
                 // Botón de descarga para el gráfico hijo
                 document.getElementById('export-sub-sankey').onclick = function() {
-                    const url = subSankeyChart.getDataURL({ type: 'png', pixelRatio: 2, backgroundColor: '#fff' });
+                    const background = getComputedStyle(subSankeyContainer).backgroundColor;
+                    const url = subSankeyChart.getDataURL({
+                        type: 'png',
+                        pixelRatio: 3,
+                        backgroundColor: background
+                    });
                     const a = document.createElement('a');
                     a.href = url;
                     a.download = `detalle_flujo_${centerNodeName}.png`;

--- a/sankey_config.js
+++ b/sankey_config.js
@@ -84,7 +84,7 @@ window.sankeyConfig = {
     // Configuración general del layout
     layoutConfig: {
         nodeAlign: 'left', // 'left' respeta mejor las posiciones Y manuales
-        nodeGap: 25, // Más espacio para evitar empalmes verticales
+        nodeGap: 40, // Más espacio para evitar empalmes verticales y facilitar el arrastre
         nodeWidth: 15, // Nodos más delgados
         layoutIterations: 0, // 0 = respeta tu orden manual completamente
         curveness: 0.8 // Líneas menos curvas


### PR DESCRIPTION
## Summary
- Rebuild sub-sankey with ECharts `sankey` series so links distribute along node edges without arrowheads
- Render sub-sankey labels in black and export high-resolution PNGs using the card's background color instead of white
- Space link labels to prevent overlap by enabling `edgeLabel` and offsetting them based on link direction
- Enlarge main and sub-sankey canvases to provide more vertical space
- Remove PJ values from sub-sankey node labels, leaving amounts only on link labels
- Increase node gap and add margins so both sankey views offer more space for dragging

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890fa4a1890832faeb1ca92cd4c3015