### PR TITLE
Fix sub-sankey links and add zoom and focus toggles

### DIFF
--- a/data_processor.js
+++ b/data_processor.js
@@ -70,7 +70,10 @@ window.dataProcessor = {
                                 source: source,
                                 target: target,
                                 value: Math.abs(value),
-                                lineStyle: { color: config.energeticColors[hijo["Nodo Hijo"]] || '#888' } // Asignar color del energético
+                                lineStyle: {
+                                    color: config.energeticColors[hijo["Nodo Hijo"]] || '#888',
+                                    opacity: 0.7
+                                } // Asignar color del energético con mayor definición
                             });
                         }
                     }

--- a/index.html
+++ b/index.html
@@ -398,7 +398,7 @@
             display: flex;
             flex-direction: column;
             position: relative;
-            height: 70vh; /* Altura fija para el contenedor */
+            height: 90vh; /* Altura fija para el contenedor */
         }
 
         footer {
@@ -678,6 +678,10 @@
             border: 1px solid rgba(255, 255, 255, 0.1);
         }
 
+        #sub-sankey-container {
+            background: #fff;
+        }
+
         .card-inset h4 {
             margin-top: 0;
             color: var(--primary-color);
@@ -894,6 +898,28 @@
                         </label>
                     </div>
                 </div>
+                <div class="control-group">
+                    <div class="toggle-container">
+                        <label class="toggle-label">
+                            <span class="toggle-text">Habilitar Zoom</span>
+                            <div class="toggle-switch">
+                                <input type="checkbox" id="zoom-switch" checked>
+                                <span class="toggle-slider"></span>
+                            </div>
+                        </label>
+                    </div>
+                </div>
+                <div class="control-group">
+                    <div class="toggle-container">
+                        <label class="toggle-label">
+                            <span class="toggle-text">Fijar foco</span>
+                            <div class="toggle-switch">
+                                <input type="checkbox" id="focus-switch">
+                                <span class="toggle-slider"></span>
+                            </div>
+                        </label>
+                    </div>
+                </div>
             </div>
         </div>
 
@@ -946,7 +972,7 @@
 
             <div id="sub-sankey-container" class="card-inset" style="display: none; margin-top: 2rem;">
                 <h4>Vista Detallada del Flujo (Nodos Arrastrables)</h4>
-                <div id="sub-sankey-chart" style="height: 400px; width: 100%;"></div>
+                <div id="sub-sankey-chart" style="height: 600px; width: 100%;"></div>
                 <button id="export-sub-sankey" class="btn" style="margin-top: 1rem;">Descargar Vista Detallada</button>
             </div>
         </div>
@@ -998,10 +1024,16 @@
             const yearSelector = document.getElementById('year-selector');
             const searchInput = document.getElementById('search-input');
             const nodeDatalist = document.getElementById('node-list');
+            const zoomSwitch = document.getElementById('zoom-switch');
+            let zoomEnabled = zoomSwitch.checked;
+            const focusSwitch = document.getElementById('focus-switch');
+            let focusMode = focusSwitch.checked;
+            let focusedNodeIndex = null;
 
             let energyData = window.energyData;
             let allNodes = new Map(); // Para guardar la info completa de los nodos
             let currentLinks = []; // Para guardar los enlaces actuales
+            let currentNodes = []; // Para guardar los nodos actuales
 
             const formatNumber = (num) => num.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 }) + ' PJ';
 
@@ -1010,7 +1042,7 @@
 
                 const processedData = window.dataProcessor.processSankeyData(energyData, year, window.sankeyConfig);
                 const { nodes } = processedData;
-                currentLinks = processedData.links; // Guardar los enlaces
+                currentLinks = processedData.links.map(link => JSON.parse(JSON.stringify(link))); // Guardar los enlaces
 
                 // Guardar nodos para tooltip y búsqueda, y aplicar indicadores visuales
                 allNodes.clear();
@@ -1055,6 +1087,8 @@
                         }
                     }
                 });
+
+                currentNodes = nodes.map(node => JSON.parse(JSON.stringify(node))); // Clonar nodos base
 
                 if (currentLinks.length === 0) {
                     sankeyChart.clear();
@@ -1109,10 +1143,13 @@
                     },
                     series: [{
                         type: 'sankey',
-                        roam: true, // Habilitar zoom y arrastre
+                        top: 20,
+                        bottom: 20,
+                        roam: zoomEnabled,
+                        draggable: focusMode || !zoomEnabled,
                         data: nodes,
                         links: currentLinks,
-                        emphasis: { focus: 'adjacency' },
+                        emphasis: { focus: focusMode ? 'none' : 'adjacency' },
                         nodeAlign: window.sankeyConfig.layoutConfig.nodeAlign,
                         nodeGap: window.sankeyConfig.layoutConfig.nodeGap,
                         nodeWidth: window.sankeyConfig.layoutConfig.nodeWidth,
@@ -1124,6 +1161,9 @@
                 };
                 sankeyChart.setOption(option, true);
                 populateDatalist(nodes);
+                focusedNodeIndex = null;
+                document.getElementById('node-details-container').style.display = 'none';
+                document.getElementById('sub-sankey-container').style.display = 'none';
             }
 
             function populateDatalist(nodes) {
@@ -1307,8 +1347,86 @@
 
             let subSankeyChart = null; // Variable para el gráfico hijo
 
+            function restoreFocus() {
+                const seriesUpdate = {
+                    data: currentNodes,
+                    links: currentLinks,
+                    roam: zoomEnabled,
+                    draggable: focusMode || !zoomEnabled,
+                    emphasis: { focus: focusMode ? 'none' : 'adjacency' }
+                };
+                sankeyChart.setOption({ series: [seriesUpdate] }, true);
+            }
+
+            function applyFocus(nodeIndex) {
+                const nodes = JSON.parse(JSON.stringify(currentNodes));
+                const links = JSON.parse(JSON.stringify(currentLinks));
+                const connected = new Set([nodeIndex]);
+
+                links.forEach(link => {
+                    const sourceIndex = nodes.findIndex(n => n.name === link.source);
+                    const targetIndex = nodes.findIndex(n => n.name === link.target);
+                    if (sourceIndex === nodeIndex || targetIndex === nodeIndex) {
+                        connected.add(sourceIndex);
+                        connected.add(targetIndex);
+                    }
+                });
+
+                nodes.forEach((node, idx) => {
+                    if (!connected.has(idx)) {
+                        node.itemStyle = node.itemStyle || {};
+                        node.itemStyle.opacity = 0.2;
+                        node.label = node.label || {};
+                        node.label.show = false;
+                    } else {
+                        node.itemStyle = node.itemStyle || {};
+                        node.itemStyle.opacity = 1;
+                        node.label = node.label || {};
+                        node.label.show = true;
+                    }
+                });
+
+                links.forEach(link => {
+                    const sourceIndex = nodes.findIndex(n => n.name === link.source);
+                    const targetIndex = nodes.findIndex(n => n.name === link.target);
+                    link.lineStyle = link.lineStyle || {};
+                    if (connected.has(sourceIndex) && connected.has(targetIndex)) {
+                        link.lineStyle.opacity = 1;
+                    } else {
+                        link.lineStyle.opacity = 0.2;
+                    }
+                });
+
+                sankeyChart.setOption({
+                    series: [{
+                        data: nodes,
+                        links: links,
+                        roam: zoomEnabled,
+                        draggable: true,
+                        emphasis: { focus: 'none' }
+                    }]
+                }, true);
+            }
+
             sankeyChart.on('click', function (params) {
                 console.log('Click en Sankey:', params);
+                if (focusMode) {
+                    if (params.dataType === 'node' && !params.name.startsWith('SPACER')) {
+                        if (focusedNodeIndex === params.dataIndex) {
+                            restoreFocus();
+                            focusedNodeIndex = null;
+                        } else {
+                            applyFocus(params.dataIndex);
+                            focusedNodeIndex = params.dataIndex;
+                        }
+                    } else {
+                        restoreFocus();
+                        focusedNodeIndex = null;
+                    }
+                    document.getElementById('node-details-container').style.display = 'none';
+                    document.getElementById('sub-sankey-container').style.display = 'none';
+                    return;
+                }
                 if (params.dataType === 'node' && !params.name.startsWith('SPACER')) {
                     const nodeInfo = allNodes.get(params.name);
 
@@ -1528,6 +1646,7 @@
             // --- Lógica de Zoom y Paneo con Transformaciones CSS ---
             const wrapper = document.getElementById('chart-wrapper');
             const sankeyDom = document.getElementById('sankey');
+            sankeyDom.style.cursor = zoomEnabled ? 'grab' : 'default';
             let scale = 1, panX = 0, panY = 0, isPanning = false, startX, startY;
 
             function updateTransform() {
@@ -1535,6 +1654,7 @@
             }
 
             wrapper.addEventListener('wheel', e => {
+                if (!zoomEnabled) return;
                 e.preventDefault();
                 const delta = e.deltaY > 0 ? -0.1 : 0.1;
 
@@ -1554,13 +1674,14 @@
                     // Ajustar el paneo para que el zoom se centre en el cursor
                     panX = mouseX - (mouseX - panX) * (newScale / scale);
                     panY = mouseY - (mouseY - panY) * (newScale / scale);
-                    
+
                     scale = newScale;
                 }
                 updateTransform();
             });
 
             sankeyDom.addEventListener('mousedown', e => {
+                if (!zoomEnabled) return;
                 isPanning = true;
                 startX = e.clientX - panX;
                 startY = e.clientY - panY;
@@ -1568,15 +1689,16 @@
             });
 
             document.addEventListener('mousemove', e => {
-                if (!isPanning) return;
+                if (!zoomEnabled || !isPanning) return;
                 panX = e.clientX - startX;
                 panY = e.clientY - startY;
                 updateTransform();
             });
 
             document.addEventListener('mouseup', () => {
+                if (!isPanning) return;
                 isPanning = false;
-                sankeyDom.style.cursor = 'grab';
+                sankeyDom.style.cursor = zoomEnabled ? 'grab' : 'default';
             });
 
             document.getElementById('zoom-reset-btn').onclick = function() {
@@ -1585,6 +1707,26 @@
                 panY = 0;
                 updateTransform();
             };
+
+            zoomSwitch.addEventListener('change', () => {
+                zoomEnabled = zoomSwitch.checked;
+                scale = 1;
+                panX = 0;
+                panY = 0;
+                updateTransform();
+                sankeyDom.style.cursor = zoomEnabled ? 'grab' : 'default';
+                if (focusMode && focusedNodeIndex !== null) {
+                    applyFocus(focusedNodeIndex);
+                } else {
+                    restoreFocus();
+                }
+            });
+
+            focusSwitch.addEventListener('change', () => {
+                focusMode = focusSwitch.checked;
+                focusedNodeIndex = null;
+                restoreFocus();
+            });
 
             window.addEventListener('resize', () => {
                 sankeyChart.resize();
@@ -1603,79 +1745,49 @@
                 }
                 subSankeyChart = echarts.init(subChartDom);
 
-                const nodes = [];
                 const links = [];
                 const nodeMap = new Map();
                 const totalFlow = centerNodeInfo.inflow > 0 ? centerNodeInfo.inflow : centerNodeInfo.outflow;
 
-                // Función para escalar el tamaño de los nodos (alto del rectángulo)
-                const scaleNodeSize = (value) => {
-                    if (totalFlow === 0) return [30, 30]; // Tamaño base
-                    const height = Math.max(20, (value / totalFlow) * 200 + 15); // Mínimo 20px de alto
-                    return [30, height]; // Ancho fijo, alto proporcional
-                };
-
-                // Función para escalar el grosor de los enlaces
-                const scaleLinkWidth = (value) => {
-                    if (totalFlow === 0) return 1;
-                    return Math.max(1, (value / totalFlow) * 25);
-                };
-
-                // Añadir el nodo central
+                // Registrar nodo central
                 nodeMap.set(centerNodeName, {
-                    name: `${centerNodeName}\n(${formatNumber(totalFlow)})`,
+                    name: centerNodeName,
                     value: totalFlow,
-                    symbol: 'rect',
-                    symbolSize: scaleNodeSize(totalFlow),
-                    fixed: true, // El nodo central no se mueve
-                    x: subChartDom.clientWidth / 2,
-                    y: subChartDom.clientHeight / 2,
-                    itemStyle: { color: centerNodeInfo.itemStyle.color },
-                    label: { fontSize: 12, fontWeight: 'bold' }
+                    itemStyle: { color: centerNodeInfo.itemStyle.color }
                 });
 
-                // Añadir nodos de entrada
-                inflows.forEach((link, i) => {
+                // Registrar nodos de entrada y enlaces
+                inflows.forEach(link => {
                     const sourceNode = allNodes.get(link.source);
                     nodeMap.set(link.source, {
-                        name: `${link.source}\n(${formatNumber(link.value)})`,
+                        name: link.source,
                         value: link.value,
-                        symbol: 'rect',
-                        symbolSize: scaleNodeSize(link.value),
-                        itemStyle: { color: sourceNode.itemStyle.color },
-                        x: subChartDom.clientWidth * 0.1,
-                        y: (subChartDom.clientHeight / (inflows.length + 1)) * (i + 1)
+                        itemStyle: { color: sourceNode.itemStyle.color }
                     });
                     links.push({
                         source: link.source,
                         target: centerNodeName,
                         value: link.value,
                         lineStyle: {
-                            width: scaleLinkWidth(link.value),
                             color: sourceNode.itemStyle.color || '#888',
                             opacity: 0.7
                         }
                     });
                 });
 
-                // Añadir nodos de salida
-                outflows.forEach((link, i) => {
+                // Registrar nodos de salida y enlaces
+                outflows.forEach(link => {
                     const targetNode = allNodes.get(link.target);
                     nodeMap.set(link.target, {
-                        name: `${link.target}\n(${formatNumber(link.value)})`,
+                        name: link.target,
                         value: link.value,
-                        symbol: 'rect',
-                        symbolSize: scaleNodeSize(link.value),
-                        itemStyle: { color: targetNode.itemStyle.color },
-                        x: subChartDom.clientWidth * 0.9,
-                        y: (subChartDom.clientHeight / (outflows.length + 1)) * (i + 1)
+                        itemStyle: { color: targetNode.itemStyle.color }
                     });
                     links.push({
                         source: centerNodeName,
                         target: link.target,
                         value: link.value,
                         lineStyle: {
-                            width: scaleLinkWidth(link.value),
                             color: centerNodeInfo.itemStyle.color || '#888',
                             opacity: 0.7
                         }
@@ -1685,21 +1797,45 @@
                 const option = {
                     tooltip: {},
                     series: [{
-                        type: 'graph',
-                        layout: 'none',
-                        roam: false,
-                        draggable: true,
+                        type: 'sankey',
+                        top: 20,
+                        bottom: 20,
                         data: Array.from(nodeMap.values()),
                         links: links,
-                        edgeSymbol: ['none', 'arrow'],
-                        edgeSymbolSize: 10,
-                        label: { show: true, position: 'inside', formatter: '{b}', color: '#fff', textBorderColor: '#000', textBorderWidth: 2 },
+                        nodeWidth: 30,
+                        nodeGap: 30,
+                        label: {
+                            formatter: function(params) {
+                                return params.data.name;
+                            },
+                            color: '#000',
+                            fontSize: 12,
+                            fontWeight: 'bold'
+                        },
+                        edgeLabel: {
+                            show: true,
+                            color: '#000',
+                            fontSize: 11,
+                            formatter: function(params) {
+                                return formatNumber(params.data.value);
+                            }
+                        },
+                        labelLayout: function(params) {
+                            if (params.dataType === 'edge') {
+                                const link = links[params.dataIndex];
+                                const isInflow = link.target === centerNodeName;
+                                return {
+                                    x: params.labelRect.x + (isInflow ? -8 : 8),
+                                    align: isInflow ? 'right' : 'left',
+                                    verticalAlign: 'middle'
+                                };
+                            }
+                        },
                         lineStyle: {
-                            curveness: 0.3,
+                            curveness: 0.5
                         },
                         emphasis: {
-                            focus: 'adjacency',
-                            lineStyle: { width: 10 }
+                            focus: 'adjacency'
                         }
                     }]
                 };
@@ -1708,7 +1844,12 @@
 
                 // Botón de descarga para el gráfico hijo
                 document.getElementById('export-sub-sankey').onclick = function() {
-                    const url = subSankeyChart.getDataURL({ type: 'png', pixelRatio: 2, backgroundColor: '#fff' });
+                    const background = getComputedStyle(subSankeyContainer).backgroundColor;
+                    const url = subSankeyChart.getDataURL({
+                        type: 'png',
+                        pixelRatio: 3,
+                        backgroundColor: background
+                    });
                     const a = document.createElement('a');
                     a.href = url;
                     a.download = `detalle_flujo_${centerNodeName}.png`;

--- a/sankey_config.js
+++ b/sankey_config.js
@@ -84,7 +84,7 @@ window.sankeyConfig = {
     // Configuración general del layout
     layoutConfig: {
         nodeAlign: 'left', // 'left' respeta mejor las posiciones Y manuales
-        nodeGap: 25, // Más espacio para evitar empalmes verticales
+        nodeGap: 45, // Un poco más de espacio para evitar empalmes y facilitar el arrastre
         nodeWidth: 15, // Nodos más delgados
         layoutIterations: 0, // 0 = respeta tu orden manual completamente
         curveness: 0.8 // Líneas menos curvas


### PR DESCRIPTION
## Summary
- Rebuild sub-sankey with ECharts `sankey` series so links distribute along node edges without arrowheads
- Render sub-sankey labels in black and export high-resolution PNGs using the card's background color instead of white
- Space link labels to prevent overlap by enabling `edgeLabel` and offsetting them based on link direction
- Enlarge main and sub-sankey canvases to provide more vertical space
- Remove PJ values from sub-sankey node labels, leaving amounts only on link labels
- Increase node gap and add margins so both sankey views offer more space for dragging
- Display the sub-sankey on a white background and darken main sankey links while slightly increasing their spacing
- Add a "Habilitar Zoom" switch that toggles zoom/pan on the main sankey and enables node dragging when zoom is off
- Add a "Fijar foco" switch that locks adjacency focus on a clicked node while keeping nodes draggable and hiding detail panels
- Prevent hover highlight while focus mode is active so only the clicked node remains emphasized
- Fade non-adjacent nodes and links when focus mode is active, restoring the full diagram when focus is cleared

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890fa4a1890832faeb1ca92cd4c3015